### PR TITLE
ci: upload test coverage information to codacy

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -41,3 +41,9 @@ jobs:
                 token: ${{ secrets.CODECOV_TOKEN }}
                 verbose: true
                 working-directory: .
+            - name: Run codacy-coverage-reporter
+              uses: codacy/codacy-coverage-reporter-action@v1.3.0
+              with:
+                project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+                coverage-reports: cobertura.xml
+                language: Rust


### PR DESCRIPTION
### TL;DR

Added Codacy coverage reporting to the GitHub workflow.

### What changed?

Added a new step to the code coverage workflow that uses the Codacy coverage reporter action (v1.3.0) to send coverage data to Codacy. The step is configured to use a Codacy project token from secrets, reads from the cobertura.xml coverage report, and specifies Rust as the language.

### How to test?

1. Ensure the `CODACY_PROJECT_TOKEN` secret is properly set in the repository settings
2. Run the code coverage workflow
3. Verify that coverage data appears in the Codacy dashboard for the project

### Why make this change?

This change enhances our code quality monitoring by adding Codacy as an additional coverage reporting tool alongside the existing Codecov integration. Having multiple coverage reporting services provides redundancy and additional insights into code quality metrics.