### PR TITLE
ci: change name of the codacy step

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -41,7 +41,7 @@ jobs:
                 token: ${{ secrets.CODECOV_TOKEN }}
                 verbose: true
                 working-directory: .
-            - name: Run codacy-coverage-reporter
+            - name: Upload coverage reports to Codacy
               uses: codacy/codacy-coverage-reporter-action@v1.3.0
               with:
                 project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
### TL;DR

Updated the GitHub workflow step name for Codacy coverage reporting to be more descriptive.

### What changed?

Changed the name of the GitHub workflow step from "Run codacy-coverage-reporter" to "Upload coverage reports to Codacy" in the code_coverage.yaml workflow file. This provides a clearer description of what the step actually does.

### How to test?

Run the code coverage GitHub workflow and verify that the step appears with the new name in the workflow execution UI.

### Why make this change?

This change improves clarity in the workflow UI by using a more descriptive name that better explains the purpose of the step - uploading coverage reports to Codacy rather than just running a reporter.