### PR TITLE
ci: pin the codacy coverage generator action to a SHA

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -42,7 +42,7 @@ jobs:
                 verbose: true
                 working-directory: .
             - name: Upload coverage reports to Codacy
-              uses: codacy/codacy-coverage-reporter-action@v1.3.0
+              uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # 1.3.0
               with:
                 project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
                 coverage-reports: cobertura.xml


### PR DESCRIPTION
### TL;DR

Pin Codacy coverage reporter action to a specific commit hash for improved security.

### What changed?

Updated the Codacy coverage reporter action reference in the GitHub workflow from using a version tag (`v1.3.0`) to using a specific commit hash (`89d6c85cfafaec52c72b6c5e8b2878d33104c699`), while maintaining the same version (1.3.0) as a comment.

### How to test?

Run the code coverage workflow to verify that the Codacy coverage reporter still functions correctly with the pinned commit hash.

### Why make this change?

Pinning GitHub Actions to specific commit hashes rather than version tags is a security best practice. This prevents potential supply chain attacks where a malicious actor could replace the code behind a version tag. Using a commit hash ensures we're always using the exact same verified code.