### PR TITLE
fix: update the length of an excuse

### DIFF
--- a/src/gh_bofh_lib/excuses.rs
+++ b/src/gh_bofh_lib/excuses.rs
@@ -26,7 +26,7 @@
 /// The `CLASSIC` array contains 467 different excuses, ensuring a wide variety
 /// of options to choose from.
 pub const CLASSIC: [&str; 467] = [
-    "clock speed",
+    "clock speed too slow",
     "solar flares",
     "electromagnetic radiation from satellite debris",
     "static from nylon underwear",


### PR DESCRIPTION
### TL;DR

Updated the first BOFH excuse in the classic excuses list to be more descriptive.

### What changed?

Modified the first entry in the `CLASSIC` array of BOFH excuses from "clock speed" to "clock speed too slow" to provide a more complete and specific excuse.

### How to test?

Run the application and verify that when the first excuse is selected from the classic list, it now displays "clock speed too slow" instead of just "clock speed".

### Why make this change?

The original excuse "clock speed" was somewhat ambiguous and incomplete. Adding "too slow" makes it a more effective and clear excuse that better matches the style of the other excuses in the list.