### PR TITLE
tests: remove unnecessary output from tests

### DIFF
--- a/tests/test_binary_classic.rs
+++ b/tests/test_binary_classic.rs
@@ -27,7 +27,6 @@ fn test_binary_plain_default() {
 #[test]
 fn test_binary_output_classic() {
     let cmd = Command::cargo_bin("gh-bofh").unwrap().output().unwrap();
-    println!("{:#?}", cmd);
     assert!(cmd.status.success());
     assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
     assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
@@ -41,7 +40,6 @@ fn test_binary_output_flag_classic() {
         .args(["--type", "classic"])
         .output()
         .unwrap();
-    println!("{:#?}", cmd);
     assert!(cmd.status.success());
     assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
     assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
@@ -55,7 +53,6 @@ fn test_binary_output_flag_short_classic() {
         .arg("-c")
         .output()
         .unwrap();
-    println!("{:#?}", cmd);
     assert!(cmd.status.success());
     assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
     assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
@@ -69,7 +66,6 @@ fn test_binary_output_env_var_classic() {
         .env("EXCUSE_TYPE", "classic")
         .output()
         .unwrap();
-    println!("{:#?}", cmd);
     assert!(cmd.status.success());
     assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
     assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());

--- a/tests/test_binary_modern.rs
+++ b/tests/test_binary_modern.rs
@@ -48,7 +48,6 @@ fn test_binary_output_flag_short_modern() {
         .arg("-m")
         .output()
         .unwrap();
-    println!("{:?}", cmd);
     assert!(cmd.status.success());
     assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
     assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());


### PR DESCRIPTION
### TL;DR

Removed debug print statements from test files.

### What changed?

Removed all `println!` statements from the test files `test_binary_classic.rs` and `test_binary_modern.rs`. These debug print statements were outputting the command results during testing but weren't necessary for the actual test functionality.

### How to test?

Run the test suite to verify that all tests still pass:

```
cargo test
```

The tests should run more cleanly now without the debug output.

### Why make this change?

These debug print statements were likely added during development to help troubleshoot test issues but are no longer needed. Removing them makes the test output cleaner and more focused on actual test results rather than showing internal command details.