### PR TITLE
build: ignore the CHANGELOG.md file from markdownlint

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,4 @@
 ^LICENSE
 .github/**/*
 meta/LICENSE-HEADER
+CHANGELOG.md


### PR DESCRIPTION
### TL;DR

Added CHANGELOG.md to the markdownlint ignore list.

### What changed?

Updated `.markdownlintignore` to exclude CHANGELOG.md from markdownlint checks.

### How to test?

1. Run markdownlint on the project
2. Verify that CHANGELOG.md is not being linted
3. Confirm that other markdown files are still being properly linted

### Why make this change?

CHANGELOG.md often follows a specific format that may not comply with standard markdown linting rules. Excluding it from linting prevents unnecessary warnings while maintaining the established changelog format.