### PR TITLE
build: add mise tasks and files

### DIFF
--- a/.mise.audit.toml
+++ b/.mise.audit.toml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+[tools]
+"cargo:cargo-audit" = "0.21.0"

--- a/.mise.ci.toml
+++ b/.mise.ci.toml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+[tools]
+"cargo:cargo-llvm-cov" = "0.6.16"
+"cargo:cargo-nextest" = "0.9.87"

--- a/.mise.docs.toml
+++ b/.mise.docs.toml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+[tools]
+"cargo:mdbook" = "0.4.43"
+"cargo:mdbook-inline-highlighting" = "0.1.0"
+node = "22.13.0"
+"npm:vercel" = "latest"

--- a/.mise.release.toml
+++ b/.mise.release.toml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+[tools]
+"cargo:cross" = "0.2.5"
+"cargo:semantic-release-cargo" = "2.4.0"
+node = "22.13.0"
+"npm:conventional-changelog-conventionalcommits" = "8.0.0"
+"npm:semantic-release" = "24.2.1"
+"npm:semantic-release-export-data" = "1.1.0"

--- a/.mise.test.toml
+++ b/.mise.test.toml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+[tools]
+"cargo:cargo-llvm-cov" = "0.6.16"
+"cargo:cargo-nextest" = "0.9.87"
+
+[tasks.coverage]
+description = "Generate test coverage information"
+run = [
+    "cargo llvm-cov --no-report nextest --config-file nextest.toml",
+    "cargo llvm-cov --no-report --doc",
+    "cargo llvm-cov report --doctests --lcov --output-path lcov.info",
+]

--- a/.mise/tasks/audit.sh
+++ b/.mise/tasks/audit.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Audit the crate's dependencies for security issues"
+#MISE alias="a"
+#MISE sources=["Cargo.toml"]
+#MISE outputs=["Cargo.lock"]
+
+cargo audit

--- a/.mise/tasks/build-release.sh
+++ b/.mise/tasks/build-release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Generate and sign artifacts for a new release"
+#MISE alias="br"
+
+set -euo pipefail
+
+# Inputs
+BINARIES=("$@") # List of binaries to build
+TARGET=${TARGET:?}
+CROSS=${CROSS:-false}
+DIST_DIR=dist
+
+# Install dependencies for Linux when not cross-compiling
+if [[ "$(uname)" == "Linux" && "$CROSS" == "false" ]]; then
+    sudo apt update
+    sudo apt install -y musl-tools mingw-w64
+fi
+
+# Setup cargo command
+CARGO="cargo"
+if [[ "$CROSS" == "true" ]]; then
+    CARGO="cross"
+fi
+
+# Create the dist directory
+mkdir -p "$DIST_DIR"
+
+# Build and package binaries
+for BIN in "${BINARIES[@]}"; do
+    echo "Building $BIN for $TARGET..."
+    $CARGO build --bin "$BIN" --release --target "$TARGET" --verbose
+
+    # Handle Windows and non-Windows packaging
+    if [[ "$TARGET" == *windows-gnu ]]; then
+        cp "target/$TARGET/release/$BIN.exe" "$DIST_DIR/$BIN-$TARGET.exe"
+    else
+        cp "target/$TARGET/release/$BIN" "$DIST_DIR/$BIN-$TARGET"
+    fi
+
+    # Generate checksum
+    echo "Generating checksum for $BIN..."
+    shasum --algorithm 256 "$DIST_DIR/$BIN-$TARGET" >"$DIST_DIR/$BIN-$TARGET-SHA256SUM.txt"
+done

--- a/.mise/tasks/build.sh
+++ b/.mise/tasks/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Build the debug version"
+#MISE alias="b"
+#MISE depends=["clean"]
+
+cargo build --verbose

--- a/.mise/tasks/clean.sh
+++ b/.mise/tasks/clean.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Clean the stale artifacts from the directory"
+#MISE alias="c"
+
+cargo clean

--- a/.mise/tasks/deploy_to_vercel.sh
+++ b/.mise/tasks/deploy_to_vercel.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Build and Deploy the documentation website to Vercel"
+#MISE alias="docs"
+
+# Exit immediately if a command exits with a non-zero status
+set -euo pipefail
+
+# Ensure required environment variables are set
+if [[ -z "$PROJECT_ENVIRONMENT" || -z "$VERCEL_TOKEN" ]]; then
+    echo "Error: PROJECT_ENVIRONMENT and VERCEL_TOKEN must be set."
+    exit 1
+fi
+
+# Step 1: Populate Preview Variables
+echo "Populating Vercel environment variables for environment: $PROJECT_ENVIRONMENT"
+vercel pull --yes --environment="$PROJECT_ENVIRONMENT" --token="$VERCEL_TOKEN"
+
+# Step 2: Build the Book
+echo "Building the book..."
+mdbook build guide
+
+# Common options for Vercel build and deploy commands
+BUILD_OPTIONS="--cwd guide/book --token=$VERCEL_TOKEN --yes --debug"
+DEPLOY_OPTIONS="--prebuilt $BUILD_OPTIONS --yes --debug"
+
+if [[ "$PROJECT_ENVIRONMENT" == "preview" ]]; then
+    echo "Building and deploying for Vercel (preview)..."
+    vercel build "$BUILD_OPTIONS"
+    vercel deploy "$DEPLOY_OPTIONS" >deployment_url
+elif [[ "$PROJECT_ENVIRONMENT" == "production" ]]; then
+    echo "Building and deploying for Vercel (production)..."
+    vercel build "$BUILD_OPTIONS"
+    vercel deploy "$DEPLOY_OPTIONS" --prod >deployment_url
+else
+    echo "Error: Unknown PROJECT_ENVIRONMENT value: $PROJECT_ENVIRONMENT"
+    exit 1
+fi
+
+# Output deployment URL
+echo "Deployment completed. Deployment URL:"
+cat deployment_url

--- a/.mise/tasks/format-check.sh
+++ b/.mise/tasks/format-check.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Format the codebase to the rustfmt standard"
+
+cargo +nightly fmt --all -- --check

--- a/.mise/tasks/format.sh
+++ b/.mise/tasks/format.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Format the codebase to the rustfmt standard"
+
+cargo +nightly fmt --all

--- a/.mise/tasks/get-next-version.sh
+++ b/.mise/tasks/get-next-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Dry-run semantic-release to see whether we are doing a release"
+
+semantic-release \
+    --dry-run \
+    --plugins semantic-release-export-data \
+    --verify-conditions semantic-release-export-data \
+    --verify-release '' \
+    --generate-notes semantic-release-export-data \
+    --prepare '' \
+    --publish '' \
+    --success '' \
+    --fail ''

--- a/.mise/tasks/lint.sh
+++ b/.mise/tasks/lint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Lint the codebase"
+
+cargo clippy -- -D warnings

--- a/.mise/tasks/test.sh
+++ b/.mise/tasks/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Run all the tests locally"
+#MISE alias="ta"
+#MISE inputs=["Cargo.toml", "src/**/*.rs"]
+#MISE outputs=["target/debug/tactix*"]
+#MISE depends=["clean", "build"]
+
+cargo nextest run

--- a/.mise/tasks/utils/fix-lockfile.sh
+++ b/.mise/tasks/utils/fix-lockfile.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Rebuild the Cargo.lock file after fixing conflicts"
+
+if [ -f Cargo.lock ]; then
+    echo "Removing the conflicted Cargo.lock file"
+    rm -v Cargo.lock
+    echo "Updating the cargo dependencies"
+    cargo update
+elif [[ -f Cargo.toml ]]; then
+    echo "No existing lock file found. Updating"
+    cargo update
+else
+    echo "Likely not in a rust project. Aborting"
+    exit 1
+fi

--- a/.mise/tasks/utils/generate-about.sh
+++ b/.mise/tasks/utils/generate-about.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+#MISE description="Generate the cargo-about files"
+#MISE dir="{{cwd}}"
+
+"./scripts/generate_about_json.sh"
+"./scripts/generate_about_md.sh ./meta/licenses.hbs"


### PR DESCRIPTION
# Add mise configuration and task scripts

### TL;DR

Add mise configuration files and task scripts to standardize development workflows.

### What changed?

- Added multiple `.mise.*.toml` configuration files for different development contexts:
  - `.mise.audit.toml` - Security auditing tools
  - `.mise.ci.toml` - CI testing tools
  - `.mise.docs.toml` - Documentation generation tools
  - `.mise.release.toml` - Release management tools
  - `.mise.test.toml` - Testing tools and tasks

- Added task scripts in `.mise/tasks/` for common development operations:
  - Build tasks (`build.sh`, `build-release.sh`)
  - Testing tasks (`test.sh`)
  - Code quality tasks (`format.sh`, `format-check.sh`, `lint.sh`)
  - Documentation tasks (`deploy_to_vercel.sh`)
  - Release management tasks (`get-next-version.sh`)
  - Utility tasks (`clean.sh`, `audit.sh`, `fix-lockfile.sh`, `generate-about.sh`)

### How to test?

1. Install mise: https://mise.jdx.dev/getting-started.html
2. Run various mise tasks to verify they work correctly:
   ```bash
   mise run build
   mise run test
   mise run lint
   ```

### Why make this change?

This change standardizes development workflows and tool versions across the project, making it easier for contributors to set up their environment and run common tasks. The mise configuration ensures consistent tooling across different development contexts (testing, documentation, releases) while the task scripts provide standardized commands for common operations.