### PR TITLE
style: ignore unwraps in tests

### DIFF
--- a/src/gh_bofh/cli.rs
+++ b/src/gh_bofh/cli.rs
@@ -93,6 +93,7 @@ pub struct Cli {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use sealed_test::prelude::*;
 

--- a/tests/test_binary_classic.rs
+++ b/tests/test_binary_classic.rs
@@ -14,60 +14,63 @@
 //! - Running the binary with the `-c` short argument.
 //! - Running the binary with the `EXCUSE_TYPE` environment variable set to
 //!   `classic`.
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use assert_cmd::Command;
+    use gh_bofh_lib::CLASSIC;
 
-use assert_cmd::Command;
-use gh_bofh_lib::CLASSIC;
+    #[test]
+    fn test_binary_plain_default() {
+        let mut cmd = Command::cargo_bin("gh-bofh").unwrap();
+        cmd.assert().success();
+    }
 
-#[test]
-fn test_binary_plain_default() {
-    let mut cmd = Command::cargo_bin("gh-bofh").unwrap();
-    cmd.assert().success();
-}
+    #[test]
+    fn test_binary_output_classic() {
+        let cmd = Command::cargo_bin("gh-bofh").unwrap().output().unwrap();
+        assert!(cmd.status.success());
+        assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+        assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+        assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+    }
 
-#[test]
-fn test_binary_output_classic() {
-    let cmd = Command::cargo_bin("gh-bofh").unwrap().output().unwrap();
-    assert!(cmd.status.success());
-    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
-    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
-    assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
-}
+    #[test]
+    fn test_binary_output_flag_classic() {
+        let cmd = Command::cargo_bin("gh-bofh")
+            .unwrap()
+            .args(["--type", "classic"])
+            .output()
+            .unwrap();
+        assert!(cmd.status.success());
+        assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+        assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+        assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+    }
 
-#[test]
-fn test_binary_output_flag_classic() {
-    let cmd = Command::cargo_bin("gh-bofh")
-        .unwrap()
-        .args(["--type", "classic"])
-        .output()
-        .unwrap();
-    assert!(cmd.status.success());
-    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
-    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
-    assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
-}
+    #[test]
+    fn test_binary_output_flag_short_classic() {
+        let cmd = Command::cargo_bin("gh-bofh")
+            .unwrap()
+            .arg("-c")
+            .output()
+            .unwrap();
+        assert!(cmd.status.success());
+        assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+        assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+        assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+    }
 
-#[test]
-fn test_binary_output_flag_short_classic() {
-    let cmd = Command::cargo_bin("gh-bofh")
-        .unwrap()
-        .arg("-c")
-        .output()
-        .unwrap();
-    assert!(cmd.status.success());
-    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
-    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
-    assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
-}
-
-#[test]
-fn test_binary_output_env_var_classic() {
-    let cmd = Command::cargo_bin("gh-bofh")
-        .unwrap()
-        .env("EXCUSE_TYPE", "classic")
-        .output()
-        .unwrap();
-    assert!(cmd.status.success());
-    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
-    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
-    assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+    #[test]
+    fn test_binary_output_env_var_classic() {
+        let cmd = Command::cargo_bin("gh-bofh")
+            .unwrap()
+            .env("EXCUSE_TYPE", "classic")
+            .output()
+            .unwrap();
+        assert!(cmd.status.success());
+        assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+        assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+        assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+    }
 }

--- a/tests/test_binary_modern.rs
+++ b/tests/test_binary_modern.rs
@@ -16,53 +16,57 @@
 //! - Running the binary with the `EXCUSE_TYPE` environment variable set to
 //!   `modern`.
 
-use assert_cmd::Command;
-use gh_bofh_lib::MODERN;
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use assert_cmd::Command;
+    use gh_bofh_lib::MODERN;
 
-#[test]
-fn test_binary_output_modern() {
-    let cmd = Command::cargo_bin("gh-bofh").unwrap().output().unwrap();
-    assert!(cmd.status.success());
-    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
-    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
-    assert!(!MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
-}
+    #[test]
+    fn test_binary_output_modern() {
+        let cmd = Command::cargo_bin("gh-bofh").unwrap().output().unwrap();
+        assert!(cmd.status.success());
+        assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+        assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+        assert!(!MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+    }
 
-#[test]
-fn test_binary_output_flag_modern() {
-    let cmd = Command::cargo_bin("gh-bofh")
-        .unwrap()
-        .args(["--type", "modern"])
-        .output()
-        .unwrap();
-    assert!(cmd.status.success());
-    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
-    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
-    assert!(MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
-}
+    #[test]
+    fn test_binary_output_flag_modern() {
+        let cmd = Command::cargo_bin("gh-bofh")
+            .unwrap()
+            .args(["--type", "modern"])
+            .output()
+            .unwrap();
+        assert!(cmd.status.success());
+        assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+        assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+        assert!(MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+    }
 
-#[test]
-fn test_binary_output_flag_short_modern() {
-    let cmd = Command::cargo_bin("gh-bofh")
-        .unwrap()
-        .arg("-m")
-        .output()
-        .unwrap();
-    assert!(cmd.status.success());
-    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
-    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
-    assert!(MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
-}
+    #[test]
+    fn test_binary_output_flag_short_modern() {
+        let cmd = Command::cargo_bin("gh-bofh")
+            .unwrap()
+            .arg("-m")
+            .output()
+            .unwrap();
+        assert!(cmd.status.success());
+        assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+        assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+        assert!(MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+    }
 
-#[test]
-fn test_binary_output_env_var_modern() {
-    let cmd = Command::cargo_bin("gh-bofh")
-        .unwrap()
-        .env("EXCUSE_TYPE", "modern")
-        .output()
-        .unwrap();
-    assert!(cmd.status.success());
-    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
-    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
-    assert!(MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+    #[test]
+    fn test_binary_output_env_var_modern() {
+        let cmd = Command::cargo_bin("gh-bofh")
+            .unwrap()
+            .env("EXCUSE_TYPE", "modern")
+            .output()
+            .unwrap();
+        assert!(cmd.status.success());
+        assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+        assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+        assert!(MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+    }
 }

--- a/tests/test_common_excuses.rs
+++ b/tests/test_common_excuses.rs
@@ -14,26 +14,28 @@
 //! - Verifying that the generated excuses are unique up to a certain limit.
 //! - Checking that all generated excuses are part of the predefined `CLASSIC`
 //!   set.
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
 
-use std::collections::HashSet;
+    use gh_bofh_lib::{
+        random_classic,
+        CLASSIC,
+    };
 
-use gh_bofh_lib::{
-    random_classic,
-    CLASSIC,
-};
+    #[test]
+    fn test_common_excuses() {
+        let mut excuses = HashSet::new();
+        for _ in 0..500 {
+            let excuse = random_classic();
+            assert!(!excuse.is_empty());
+            assert_ne!(excuse, "No excuse found, try again later");
+            excuses.insert(excuse);
+        }
 
-#[test]
-fn test_common_excuses() {
-    let mut excuses = HashSet::new();
-    for _ in 0..500 {
-        let excuse = random_classic();
-        assert!(!excuse.is_empty());
-        assert_ne!(excuse, "No excuse found, try again later");
-        excuses.insert(excuse);
+        assert!(excuses.len() > 1);
+        assert!(excuses.len() <= 467);
+
+        assert!(excuses.iter().all(|excuse| CLASSIC.contains(excuse)));
     }
-
-    assert!(excuses.len() > 1);
-    assert!(excuses.len() <= 467);
-
-    assert!(excuses.iter().all(|excuse| CLASSIC.contains(excuse)));
 }


### PR DESCRIPTION
### TL;DR

Added `#[allow(clippy::unwrap_used)]` to test modules and restructured test files to properly encapsulate tests within modules.

### What changed?

- Added `#[allow(clippy::unwrap_used)]` attribute to test modules to suppress Clippy warnings about unwrap usage in tests
- Restructured test files by wrapping test functions in `mod tests {}` blocks with proper `#[cfg(test)]` attributes
- Maintained all existing test functionality while improving code organization

### How to test?

1. Run the test suite to ensure all tests still pass:
   ```
   cargo test
   ```
2. Run clippy to verify no unwrap warnings are reported in test code:
   ```
   cargo clippy
   ```

### Why make this change?

This change improves code quality by:
1. Explicitly acknowledging that unwrap usage is acceptable in test code
2. Following Rust's best practices for test organization by properly encapsulating tests in modules
3. Ensuring consistent test structure across the codebase

The changes make the codebase more maintainable while preserving all existing test functionality.