### PR TITLE
build: put the benchmarks in a module to allow for missing_docs

### DIFF
--- a/benches/excuses_benchmark.rs
+++ b/benches/excuses_benchmark.rs
@@ -10,39 +10,49 @@
 //! designed to help identify performance bottlenecks and ensure that the
 //! functions perform efficiently under various conditions.
 
-use criterion::{
-    criterion_group,
-    criterion_main,
-    Criterion,
-};
-use gh_bofh_lib::{
-    random_classic,
-    random_modern,
-};
+use criterion::criterion_main;
 
-/// Benchmark the performance of the `random_classic` function.
-///
-/// This function measures the time it takes to generate classic excuses using
-/// the `random_classic` function from the `gh_bofh_lib` crate.
-///
-/// # Arguments
-///
-/// * `c` - A mutable reference to a `Criterion` struct used for benchmarking.
-fn benchmark_random_classic(c: &mut Criterion) {
-    c.bench_function("random_classic", |b| b.iter(random_classic));
+#[allow(missing_docs)]
+mod bench {
+    // TODO: Currently wrapping the `criterion_group` parts
+    // in their own module to allow for the missing-docs check
+    // to pass
+    // Tracking here: https://github.com/bheisler/criterion.rs/issues/826
+    use criterion::{
+        criterion_group,
+        Criterion,
+    };
+    use gh_bofh_lib::{
+        random_classic,
+        random_modern,
+    };
+
+    /// Benchmark the performance of the `random_classic` function.
+    ///
+    /// This function measures the time it takes to generate classic excuses
+    /// using the `random_classic` function from the `gh_bofh_lib` crate.
+    ///
+    /// # Arguments
+    ///
+    /// * `c` - A mutable reference to a `Criterion` struct used for
+    ///   benchmarking.
+    fn benchmark_random_classic(c: &mut Criterion) {
+        c.bench_function("random_classic", |b| b.iter(random_classic));
+    }
+
+    /// Benchmark the performance of the `random_modern` function.
+    ///
+    /// This function measures the time it takes to generate modern excuses
+    /// using the `random_modern` function from the `gh_bofh_lib` crate.
+    ///
+    /// # Arguments
+    ///
+    /// * `c` - A mutable reference to a `Criterion` struct used for
+    ///   benchmarking.
+    fn benchmark_random_modern(c: &mut Criterion) {
+        c.bench_function("random_modern", |b| b.iter(random_modern));
+    }
+
+    criterion_group!(benches, benchmark_random_classic, benchmark_random_modern);
 }
-
-/// Benchmark the performance of the `random_modern` function.
-///
-/// This function measures the time it takes to generate modern excuses using
-/// the `random_modern` function from the `gh_bofh_lib` crate.
-///
-/// # Arguments
-///
-/// * `c` - A mutable reference to a `Criterion` struct used for benchmarking.
-fn benchmark_random_modern(c: &mut Criterion) {
-    c.bench_function("random_modern", |b| b.iter(random_modern));
-}
-
-criterion_group!(benches, benchmark_random_classic, benchmark_random_modern);
-criterion_main!(benches);
+criterion_main!(bench::benches);


### PR DESCRIPTION
### TL;DR

Restructured benchmark code to fix documentation warnings by wrapping criterion_group in a module.

### What changed?

- Moved the benchmark functions and `criterion_group!` macro into a new `bench` module
- Added `#[allow(missing_docs)]` to the module to suppress documentation warnings
- Updated imports to reflect the new structure
- Added a TODO comment explaining the reason for this workaround
- Added a reference to the related Criterion issue (#826)
- Adjusted the `criterion_main!` call to reference the nested module's benches

### How to test?

1. Run the benchmarks to ensure they still work correctly:
   ```
   cargo bench
   ```
2. Verify that documentation builds without warnings:
   ```
   cargo doc --no-deps
   ```

### Why make this change?

This change addresses documentation warnings that were occurring due to how Criterion's macros interact with Rust's documentation system. By isolating the `criterion_group!` macro in a module with `#[allow(missing_docs)]`, we can maintain proper documentation coverage while still using Criterion for benchmarking. This is a workaround for a known issue in Criterion (issue #826).